### PR TITLE
Make python3/python2 compatible and update spake2 API

### DIFF
--- a/python-spake2-interop-entrypoint.py
+++ b/python-spake2-interop-entrypoint.py
@@ -2,29 +2,40 @@
 
 from __future__ import print_function, unicode_literals
 
-from sys import argv, stdout, stderr
+from binascii import hexlify, unhexlify
+from sys import argv, stderr, stdout
 
-from spake2 import params
+from spake2.parameters.ed25519 import ParamsEd25519
+from spake2.parameters.i1024 import Params1024
+from spake2.parameters.i2048 import Params2048
+from spake2.parameters.i3072 import Params3072
 
-if argv[1] == b"A":
+try:
+    # Python 2 compatibility
+    input = raw_input
+except NameError:
+    pass
+
+
+if argv[1] == "A":
     from spake2 import SPAKE2_A as SPAKE2_SIDE
-elif argv[1] == b"B":
+elif argv[1] == "B":
     from spake2 import SPAKE2_B as SPAKE2_SIDE
-elif argv[1] == b"Symmetric":
+elif argv[1] == "Symmetric":
     from spake2 import SPAKE2_Symmetric as SPAKE2_SIDE
 else:
-    raise ValueError("Specify side A or B")
+    raise ValueError("Specify side A or B: %s" % argv[1])
 
-password = argv[2]
+password = argv[2].encode('utf-8')
 
 PARAMS = {
-    'I1024': params.Params1024,
-    'I2048': params.Params2048,
-    'I3072': params.Params3072,
-    'Ed25519': params.ParamsEd25519,
+    'I1024': Params1024,
+    'I2048': Params2048,
+    'I3072': Params3072,
+    'Ed25519': ParamsEd25519,
 }
 
-param = params.ParamsEd25519
+param = ParamsEd25519
 if len(argv) > 3:
     try:
         param = PARAMS[argv[3]]
@@ -36,15 +47,15 @@ if len(argv) > 3:
 
 s = SPAKE2_SIDE(password, params=param)
 msg_out = s.start()
-print(msg_out.encode("hex"))
+print(hexlify(msg_out).decode('ascii'))
 stdout.flush()
-line = raw_input()
+line = input()
 try:
-    msg_in = line.decode("hex")
+    msg_in = unhexlify(line)
 except TypeError as e:
     stderr.write("ERROR: Could not decode line (%s): %r\n" % (e, line))
     stderr.flush()
     raise e
 key = s.finish(msg_in)
-print(key.encode("hex"))
+print(hexlify(key).decode('ascii'))
 stdout.flush()


### PR DESCRIPTION
Now script can work with both python versions.
SPAKE2 API for parameters had changed, updated it.